### PR TITLE
Add unit declarator to module declarations

### DIFF
--- a/lib/Time/Duration.pm6
+++ b/lib/Time/Duration.pm6
@@ -1,5 +1,5 @@
 use v6;
-module Time::Duration;
+unit module Time::Duration;
 # POD is at the end.
 
 constant $DEBUG = False;


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.