### PR TITLE
Fix removed @*INC

### DIFF
--- a/t/01_tdur.t
+++ b/t/01_tdur.t
@@ -3,7 +3,7 @@ use Test;
 plan 135;
 
 
-BEGIN { @*INC.unshift: '../lib'; }
+use lib 'lib';
 
 use Time::Duration;
 ok 1;


### PR DESCRIPTION
@*INC is no longer available. `use lib` is the new way.