### PR TITLE
Updates documentation and perl6 version

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ SYNOPSIS
 --------
 Example use in a program that ends by noting its runtime:
 
-      my $start_time = time();
+      my $start_time = time;
       use Time::Duration;
       
       # then things that take all that time, and then ends:
-      print "Runtime ", duration(time() - $start_time), ".\n";
+      print "Runtime: ", duration(time - $start_time), ".\n";
 
 Example use in a program that reports age of a file:
 
@@ -32,7 +32,7 @@ or exact terms.
 In the first example in the Synopsis, using
     duration($interval_seconds):
 
-If the `time() - $start_time' is 3 seconds, this prints "Runtime:
+If the `time - $start_time' is 3 seconds, this prints "Runtime:
 3 seconds.". If it's 0 seconds, it's "Runtime: 0 seconds.". If
 it's 1 second, it's "Runtime: 1 second.". If it's 125 seconds, you
 get "Runtime: 2 minutes and 5 seconds.". If it's 3820 seconds
@@ -206,7 +206,7 @@ INSTALLATION
 You install Time::Duration, as you would install any perl 6 module
 library, by running these commands:
 
-   panda install Time::Duration
+   zef install Time::Duration
 
 See http://modules.perl6.org/ for more information.
 

--- a/lib/Time/Duration.pm6
+++ b/lib/Time/Duration.pm6
@@ -1,4 +1,4 @@
-use v6;
+use v6.c;
 unit module Time::Duration;
 # POD is at the end.
 
@@ -215,11 +215,11 @@ Time::Duration - rounded or exact English expression of durations
 
 Example use in a program that ends by noting its runtime:
 
-  my $start_time = time();
+  my $start_time = time;
   use Time::Duration;
 
   # then things that take all that time, and then ends:
-  print "Runtime ", duration(time() - $start_time), ".\n";
+  print "Runtime: ", duration(time - $start_time), ".\n";
 
 Example use in a program that reports age of a file:
 
@@ -236,7 +236,7 @@ terms.
 
 In the first example in the Synopsis, using duration($interval_seconds):
 
-If the C<time() - $start_time> is 3 seconds, this prints
+If the C<time - $start_time> is 3 seconds, this prints
 "Runtime: B<3 seconds>.".  If it's 0 seconds, it's "Runtime: B<0 seconds>.".
 If it's 1 second, it's "Runtime: B<1 second>.".  If it's 125 seconds, you
 get "Runtime: B<2 minutes and 5 seconds>.".  If it's 3820 seconds (which


### PR DESCRIPTION
Updates from v6 to v6.c

Changes time() to time as is not a function but is a term and errors
now.

Adds colon in print statement to correspond to examples of output.

Changes installer from panda to zef.